### PR TITLE
[Feat] 상품 수정 API 추가

### DIFF
--- a/src/main/java/com/univ/market/controller/ProductController.java
+++ b/src/main/java/com/univ/market/controller/ProductController.java
@@ -108,14 +108,30 @@ public class ProductController {
         return ResponseEntity.ok(response);
     }
     
-    /**
-     * 상품 삭제 API
-     * 
-     * @param id 상품 ID
-     * @param userId 현재 인증된 사용자 ID
-     * @return 응답 없음 (204 No Content)
-     */
-    @DeleteMapping("/{id}")
+        /**
+         * 상품 수정 API
+         *
+         * @param id 상품 ID
+         * @param request 상품 수정 요청 데이터
+         * @param userId 현재 인증된 사용자 ID
+         * @return 수정된 상품 정보
+         */
+        @PutMapping("/{id}")
+        public ResponseEntity<ProductResponse> updateProduct(
+                @PathVariable Long id,
+                @RequestBody ProductRequest request,
+                @AuthenticationPrincipal Long userId) {
+            ProductResponse response = productService.updateProduct(id, request, userId);
+            return ResponseEntity.ok(response);
+        }
+    
+        /**
+         * 상품 삭제 API
+         *
+         * @param id 상품 ID
+         * @param userId 현재 인증된 사용자 ID
+         * @return 응답 없음 (204 No Content)
+         */    @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteProduct(
             @PathVariable Long id,
             @AuthenticationPrincipal Long userId) {

--- a/src/main/java/com/univ/market/domain/Product.java
+++ b/src/main/java/com/univ/market/domain/Product.java
@@ -125,4 +125,11 @@ public class Product {
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
     }
+
+    public void update(String title, String description, int price, Category category) {
+        this.title = title;
+        this.description = description;
+        this.price = price;
+        this.category = category;
+    }
 }

--- a/src/main/java/com/univ/market/service/ProductService.java
+++ b/src/main/java/com/univ/market/service/ProductService.java
@@ -197,16 +197,45 @@ public class ProductService {
         return ProductResponse.fromEntity(updatedProduct);
     }
     
-    /**
-     * 상품을 삭제하는 메서드
-     * 판매자 본인만 삭제 가능합니다.
-     * 
-     * @param productId 상품 ID
-     * @param userId 요청자 ID
-     * @throws IllegalArgumentException 존재하지 않는 상품인 경우
-     * @throws IllegalStateException 판매자가 아닌 사용자가 삭제 시도하는 경우
-     */
-    @Transactional
+        @Transactional
+        public ProductResponse updateProduct(Long productId, ProductRequest request, Long userId) {
+            Product product = productRepository.findById(productId)
+                    .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+    
+            if (!product.getSeller().getId().equals(userId)) {
+                throw new IllegalStateException("본인이 등록한 상품만 수정할 수 있습니다.");
+            }
+    
+            Category category = categoryRepository.findById(request.getCategoryId())
+                    .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+    
+            product.update(request.getTitle(), request.getDescription(), request.getPrice(), category);
+    
+            // 이미지 업데이트 로직 (기존 이미지 삭제 후 새 이미지 추가)
+            if (request.getImageUrls() != null) {
+                product.getImages().clear(); // 기존 이미지 삭제
+                List<Image> newImages = request.getImageUrls().stream()
+                        .map(url -> Image.builder()
+                                .imageUrl(url)
+                                .product(product)
+                                .build())
+                        .collect(Collectors.toList());
+                product.getImages().addAll(newImages);
+            }
+    
+            Product updatedProduct = productRepository.save(product);
+            return ProductResponse.fromEntity(updatedProduct);
+        }
+    
+        /**
+         * 상품을 삭제하는 메서드
+         * 판매자 본인만 삭제 가능합니다.
+         *
+         * @param productId 상품 ID
+         * @param userId 요청자 ID
+         * @throws IllegalArgumentException 존재하지 않는 상품인 경우
+         * @throws IllegalStateException 판매자가 아닌 사용자가 삭제 시도하는 경우
+         */    @Transactional
     public void deleteProduct(Long productId, Long userId) {
         // 상품 정보 조회
         Product product = productRepository.findById(productId)


### PR DESCRIPTION
# [Feat] 상품 수정 API 추가

> 상품 상세 페이지에 접속했을 때, 본인이 작성한 상품에 한해 수정 및 삭제를 할 수 있는 기능을 추가했습니다.                                                                                                                                                       
> 
> 1. 백엔드에 상품 수정 API가 누락되어 있어 이를 추가하고, 프론트엔드에서 해당 API를 호출하여 기능을 구현했습니다.
> 2. 상품 삭제의 경우, 백엔드 API는 이미 존재하여 프론트엔드 연동 작업만 진행했습니다.

## [Feat] 상품 수정 API 추가
- `Product.java` : 상품 정보(제목, 설명, 가격, 카테고리)를 업데이트하는 `update` 메소드를 추가했습니다.
- `ProductService.java` : `updateProduct` 메소드를 추가하여, 상품 수정 요청 시 판매자 본인인지 확인하고 상품 정보를 업데이트하는 비즈니스 로직을 구현했습니다.
- `ProductController.java` : 상품 수정을 위한 `PUT /api/products/{id}` API 엔드포인트를 추가했습니다.

<br>

테스트 시 상품 수정&삭제 기능 정상적으로 작동하는 것으로 보입니다.

<br>

@ndk4309 백엔드 부분이라 제가 잘 수정했는지 확실히 파악하기는 힘들어서, 변경된 코드 리뷰 꼭 부탁드립니다.