### PR TITLE
[Fix] 구글 로그인 관련 인증, 데이터 정합성 및 채팅방 생성 버그 수정

### DIFF
--- a/src/main/java/com/univ/market/controller/ChatController.java
+++ b/src/main/java/com/univ/market/controller/ChatController.java
@@ -70,6 +70,22 @@ public class ChatController {
         List<ChatRoomResponse> chatRooms = chatService.getMyChatRooms(userId);
         return ResponseEntity.ok(chatRooms);
     }
+
+    /**
+     * 특정 채팅방 정보 조회 API
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 현재 인증된 사용자 ID
+     * @return 채팅방 상세 정보
+     */
+    @GetMapping("/api/chat/rooms/{roomId}")
+    public ResponseEntity<ChatRoomResponse> getChatRoomById(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal Long userId) {
+        ChatRoomResponse chatRoom = chatService.getChatRoomById(roomId, userId);
+        return ResponseEntity.ok(chatRoom);
+    }
+
     
     /**
      * 채팅방 메시지 목록 조회 API

--- a/src/main/java/com/univ/market/domain/ChatRoom.java
+++ b/src/main/java/com/univ/market/domain/ChatRoom.java
@@ -47,6 +47,7 @@ public class ChatRoom {
      * 채팅 메시지 목록 (일대다 관계)
      */
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<ChatMessage> messages = new ArrayList<>();
     
     /**

--- a/src/main/java/com/univ/market/security/JwtTokenProvider.java
+++ b/src/main/java/com/univ/market/security/JwtTokenProvider.java
@@ -50,11 +50,7 @@ public class JwtTokenProvider {
      */
     @PostConstruct
     protected void init() {
-        if (secretKey.length() < 32) { // 256비트보다 작은 키 길이
-            this.key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
-        } else {
-            this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
-        }
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
     }
     
     /**


### PR DESCRIPTION
> 구글 소셜 로그인 기능 추가 이후 발생한 JWT 인증 오류, 사용자 닉네임 데이터 정합성, 채팅방 생성 문제를
  해결했습니다.
> 1.  채팅방 생성 오류 해결: 구글 사용자가 채팅방을 생성하지 못하던 문제를 해결했습니다.
> 2. JWT 인증 문제 해결: 잘못된 JWT 발급으로 인해 API 요청에서 사용자를 식별하지 못하던 문제를 수정했습니다.
> 3. 닉네임 누락 문제 해결: JPA 캐시 문제로 인해 구글 사용자의 닉네임이 `null`로 표시되던 버그를 수정했습니다.

## [Fix] JWT 인증 및 채팅방 생성 오류 수정
- `JwtTokenProvider.java` & `OAuth2SuccessHandler.java`:
1. JWT 토큰의 `subject`를 `OAuth ID`가 아닌, 내부 DB의 `userId`로 발급하도록 수정했습니다.
2. 이로써 구글 사용자가 채팅방 생성 시 `NumberFormatException`이 발생하던 근본 원인을 해결하고, 모든 API 요청에서 사용자가 올바르게 식별되도록 수정했습니다.

## [Fix] Google 로그인 시 닉네임 누락 버그 수정
- `UserService.java`: JPA 영속성 컨텍스트의 캐시 문제로 인해, 닉네임이 DB에 업데이트된 후에도 이전 정보(또는 `null`)를 조회하던 문제를 해결했습니다. `EntityManager.refresh()`를 호출하여 엔티티를 명시적으로 새로고침 함으로써 데이터 정합성을 보장했습니다.

<br>

테스트 시 채팅방 기능 정상 작동합니다.